### PR TITLE
feat(resources scroll display) : change resource list to vertical data scroller on learning unit page

### DIFF
--- a/src/components/resources-section/learning-unit-information/LearningUnitInformation.module.scss
+++ b/src/components/resources-section/learning-unit-information/LearningUnitInformation.module.scss
@@ -9,6 +9,7 @@
   display: flex;
   align-items: center;
   width: 100%;
+  justify-content: center;
 }
 
 .productListDetail {

--- a/src/components/resources-section/learning-unit-information/LearningUnitInformation.module.scss
+++ b/src/components/resources-section/learning-unit-information/LearningUnitInformation.module.scss
@@ -1,5 +1,5 @@
 .cardFull{
-  width: 100%;
+  width: 50%;
   transition: all 0.3s ease-in-out;
   display: flex;
   justify-content: space-evenly;
@@ -68,7 +68,7 @@
   }
 }
 
-@media screen and (max-width: 981px) {
+@media screen and (max-width: 980px) {
   .cardFull{
     width: 100%;
   }

--- a/src/components/resources-section/resources-list-item/ResourcesListItem.module.scss
+++ b/src/components/resources-section/resources-list-item/ResourcesListItem.module.scss
@@ -1,5 +1,5 @@
 .resourceGridItem {
-  margin: 0.5em;
+  margin-top: 0.5em;
   border: 1px solid var(--surface-border);
   padding: 1rem;
   transition: all 0.5s ease-out;

--- a/src/components/resources-section/resources-list-item/ResourcesListItem.module.scss
+++ b/src/components/resources-section/resources-list-item/ResourcesListItem.module.scss
@@ -6,7 +6,6 @@
   &:hover {
     border: 1px solid #3d3fb5;
     background-color: rgba(61, 63, 181, 0.05);
-    transform: scale(1.05);
   }
 }
 

--- a/src/components/resources-section/resources-list-item/ResourcesListItem.module.scss
+++ b/src/components/resources-section/resources-list-item/ResourcesListItem.module.scss
@@ -3,6 +3,7 @@
   border: 1px solid var(--surface-border);
   padding: 1rem;
   transition: all 0.5s ease-out;
+  border-radius: 6px;
   &:hover {
     border: 1px solid #3d3fb5;
     background-color: rgba(61, 63, 181, 0.05);

--- a/src/components/resources-section/resources-scroller/ResourceScroller.module.scss
+++ b/src/components/resources-section/resources-scroller/ResourceScroller.module.scss
@@ -1,0 +1,5 @@
+.myScroller {
+  & > [class~="p-datascroller-content"] {
+    padding: 0;
+  }
+}

--- a/src/components/resources-section/resources-scroller/ResourceScroller.module.scss
+++ b/src/components/resources-section/resources-scroller/ResourceScroller.module.scss
@@ -1,5 +1,20 @@
 .myScroller {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 0.5rem;
+  width: 100%;
   & > [class~="p-datascroller-content"] {
+    transition: all 0.3s ease-in-out;
     padding: 0;
+    width: 50%;
+  }
+}
+
+@media screen and (max-width: 980px) {
+  .myScroller {
+    & > [class~="p-datascroller-content"] {
+      width: 100%
+    }
   }
 }

--- a/src/components/resources-section/resources-scroller/ResourcesScroller.js
+++ b/src/components/resources-section/resources-scroller/ResourcesScroller.js
@@ -1,10 +1,11 @@
 import { DataScroller } from 'primereact/datascroller';
 import ResourcesListItem from '../resources-list-item/ResourcesListItem';
+import styles from './ResourceScroller.module.scss';
 
 const ResourcesScroller = ({ resources }) => {
   const itemTemplate = (resource) => <ResourcesListItem resource={resource} />;
 
-  return <DataScroller value={resources} itemTemplate={itemTemplate} rows={10} inline />;
+  return <DataScroller className={styles.myScroller} value={resources} itemTemplate={itemTemplate} rows={10} />;
 };
 
 export default ResourcesScroller;

--- a/src/components/resources-section/resources-scroller/ResourcesScroller.js
+++ b/src/components/resources-section/resources-scroller/ResourcesScroller.js
@@ -1,0 +1,10 @@
+import { DataScroller } from 'primereact/datascroller';
+import ResourcesListItem from '../resources-list-item/ResourcesListItem';
+
+const ResourcesScroller = ({ resources }) => {
+  const itemTemplate = (resource) => <ResourcesListItem resource={resource} />;
+
+  return <DataScroller value={resources} itemTemplate={itemTemplate} rows={10} inline />;
+};
+
+export default ResourcesScroller;

--- a/src/components/resources-section/resources-section/ResourcesSection.js
+++ b/src/components/resources-section/resources-section/ResourcesSection.js
@@ -5,10 +5,10 @@ import { endpoints } from '@utils/endpoints';
 import { Skeleton } from 'primereact/skeleton';
 import { Button } from 'primereact/button';
 import { Panel } from 'primereact/panel';
-import ResourcesList from '@components/resources-section/resources-list/ResourcesList';
 import AddNewResourceModal from '@components/resources-section/add-new-resource-modal/AddNewResourceModal';
 import LearningUnitInformation from '@components/resources-section/learning-unit-information/LearningUnitInformation';
 import styles from './ResourcesSection.module.scss';
+import ResourcesScroller from '../resources-scroller/ResourcesScroller';
 
 const ResourcesSection = ({ learningUnitId }) => {
   const router = useRouter();
@@ -59,7 +59,7 @@ const ResourcesSection = ({ learningUnitId }) => {
       <Panel header={header}>
         <LearningUnitInformation learningUnit={learningUnit} />
         {displayBasic && <AddNewResourceModal handlers={modalHandlers} learningUnitId={learningUnitId} />}
-        <ResourcesList resources={resources} learningUnitId={learningUnitId} />
+        <ResourcesScroller resources={resources} />
       </Panel>
     </div>
   );

--- a/src/components/resources-section/resources-section/ResourcesSection.module.scss
+++ b/src/components/resources-section/resources-section/ResourcesSection.module.scss
@@ -15,4 +15,13 @@
 .container {
   display: flex;
   flex-direction: column;
+  & > [class~="p-panel"] {
+    & > [class~="p-toggleable-content"] {
+      & > [class~="p-panel-content"] {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+      }
+    }
+  }
 }


### PR DESCRIPTION
**Base PR**
PR based on main
**Context**
With this PR, we are changing how the learning unit page is displayed, replacing the resources list with pagination to a vertical window scroller to navigate resources. 

**Changelog**

- Add ResourcesScroller component and replaced ResourcesList on ResourcesSection
- Add ResourcesScroller scss (includes overriding PrimeFaces classes). 
- Modify Learning Unit Information scss to align page and maintain width of 100%. 
- Modify ResourcesListItem scss to avoid overlapping. 
- Change ResourcesSection scss to maintain styles when using smaller screens

**QA**
Go to http://localhost:3001/learning-units/1 to see how it looks. 


After
![image](https://user-images.githubusercontent.com/12021066/197542762-85863a50-06fe-4e48-a11b-45788c0cafa9.png)

Before
![image](https://user-images.githubusercontent.com/12021066/197542670-bcfda9b6-707a-49d1-9c76-29005991a328.png)
