### PR TITLE
feat(resources-evaluation-counter): add number of resource evaluations

### DIFF
--- a/src/components/resources-section/average/Average.js
+++ b/src/components/resources-section/average/Average.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import { Rating } from 'primereact/rating';
+import styles from './Average.module.scss';
 
 const Average = ({ average }) => {
   return (
     <>
       {average !== 'NaN' ? (
         <>
-          <span>{average}</span>
+          <span className={styles.ratingNumber}>{average}</span>
           <Rating value={average} readOnly cancel={false} />
         </>
       ) : (

--- a/src/components/resources-section/average/Average.module.scss
+++ b/src/components/resources-section/average/Average.module.scss
@@ -1,0 +1,4 @@
+.ratingNumber {
+  font-size: 1.5rem;
+  font-weight: bold;
+}

--- a/src/components/resources-section/resources-list-item/ResourcesListItem.js
+++ b/src/components/resources-section/resources-list-item/ResourcesListItem.js
@@ -19,6 +19,9 @@ const ResourcesListItem = ({ resource, resourceViewButtonHandler }) => {
               <Average
                 average={parseFloat(resource.average_evaluation).toFixed(1)}
               />
+              <span className={styles.small_number}>
+                ({resource.number_of_evaluations})
+              </span>
             </div>
             <div className={styles.resourceUrl}>
               <i className="pi pi-link"></i>

--- a/src/components/resources-section/resources-list-item/ResourcesListItem.js
+++ b/src/components/resources-section/resources-list-item/ResourcesListItem.js
@@ -19,7 +19,7 @@ const ResourcesListItem = ({ resource, resourceViewButtonHandler }) => {
               <Average
                 average={parseFloat(resource.average_evaluation).toFixed(1)}
               />
-              <span className={styles.small_number}>
+              <span className={styles.smallNumber}>
                 ({resource.number_of_evaluations})
               </span>
             </div>

--- a/src/components/resources-section/resources-list-item/ResourcesListItem.module.scss
+++ b/src/components/resources-section/resources-list-item/ResourcesListItem.module.scss
@@ -69,3 +69,7 @@
   gap: 1rem;
   text-align: center;
 }
+
+.smallNumber {
+  font-size: 1rem;
+}


### PR DESCRIPTION
# Base PR
- PR based on main branch.

# Context
- With this PR, we display the number of resource evaluations of a Resource List Item. 

# Changelog
- Add new span to display 'number_of_evaluations'. 
- Add styles of number of evaluations and Average to distinguish between them on size and colour. 

# QA
- On our backend project, go to main git checkout to [main branch](https://github.com/fintual-oss/paraffin-back)
- Launch frontend App (yarn dev)
- Go to http://localhost:3001/learning-units/1 to see how it looks.

![image](https://user-images.githubusercontent.com/12021066/197607797-6f3039bb-1eb5-4454-ae72-55fa0e99b2e5.png)


