### PR TITLE
Feat graph nodes clickable, hoverable, and with real data

### DIFF
--- a/src/components/learning-units-section/graph-section/GraphSection.js
+++ b/src/components/learning-units-section/graph-section/GraphSection.js
@@ -1,0 +1,78 @@
+import React from 'react';
+import dynamic from 'next/dynamic';
+import useGet from '@hooks/useGet';
+import { endpoints } from '@utils/endpoints';
+import { Skeleton } from 'primereact/skeleton';
+
+const Graph = dynamic(
+  () => import('@components/learning-units-section/graph/Graph'),
+  {
+    ssr: false,
+  }
+);
+
+const GraphSection = ({ cycleId, handleNodeClick }) => {
+  const {
+    data: successions,
+    isLoading: isLoadingSuccessions,
+    isError: isErrorSuccessions,
+  } = useGet(endpoints('learningUnitSuccessions', cycleId));
+
+  const {
+    data: learningUnits,
+    isLoading: isLoadingLearningUnits,
+    isError: isErrorLearningUnits,
+  } = useGet(endpoints('learningUnitsOfCycle', cycleId));
+
+  if (isLoadingSuccessions || isLoadingLearningUnits) {
+    return <Skeleton shape="rectangle" width="100%" height="100%" />;
+  }
+
+  if (isErrorSuccessions || isErrorLearningUnits) {
+    return 'error';
+  }
+
+  const edges = successions.map((succession) => ({
+    source: succession['predecessor_id'].toString(),
+    target: succession['successor_id'].toString(),
+    id: `${succession['predecessor_id']}-${succession['successor_id']}`,
+  }));
+
+  const nodes = learningUnits.map((learningUnit) => ({
+    id: learningUnit.id.toString(),
+    label: learningUnit.name,
+  }));
+
+  let nodePredecessors = {};
+  nodes.forEach((node) => {
+    let nodesToSelect = [node.id];
+    let edgesToSelect = [];
+    let count = 1;
+    while (count > 0) {
+      count = 0;
+      nodesToSelect.forEach((node_id) => {
+        edges.forEach((edge) => {
+          if (edge.target === node_id && !edgesToSelect.includes(edge.id)) {
+            edgesToSelect.push(edge.id);
+            if (!nodesToSelect.includes(edge.source)) {
+              nodesToSelect.push(edge.source);
+            }
+            count += 1;
+          }
+        });
+      });
+    }
+    nodePredecessors[node.id] = nodesToSelect.concat(edgesToSelect);
+  });
+
+  return (
+    <Graph
+      nodes={nodes}
+      edges={edges}
+      nodePredecessors={nodePredecessors}
+      handleNodeClick={handleNodeClick}
+    />
+  );
+};
+
+export default GraphSection;

--- a/src/components/learning-units-section/graph/Graph.js
+++ b/src/components/learning-units-section/graph/Graph.js
@@ -1,75 +1,25 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { GraphCanvas } from 'reagraph';
 
-const dummyNodes = [
-  {
-    id: '1',
-    label: 'GitHub',
-  },
-  {
-    id: '2',
-    label: 'Ruby',
-  },
-  {
-    id: '3',
-    label: 'Rails',
-  },
-  {
-    id: '4',
-    label: 'Docker',
-  },
-  {
-    id: '5',
-    label: 'React',
-  },
-  {
-    id: '6',
-    label: 'Next',
-  },
-];
+const Graph = ({ nodes, edges, nodePredecessors, handleNodeClick }) => {
+  const [selections, setSelections] = useState([]);
 
-const dummyEdges = [
-  {
-    source: '1',
-    target: '2',
-    id: '1-2',
-  },
-  {
-    source: '2',
-    target: '3',
-    id: '2-1',
-  },
-  {
-    source: '1',
-    target: '3',
-    id: '1-3',
-  },
-  {
-    source: '1',
-    target: '5',
-    id: '1-5',
-  },
-  {
-    source: '4',
-    target: '5',
-    id: '4-5',
-  },
-  {
-    source: '4',
-    target: '6',
-    id: '4-6',
-  },
-  {
-    source: '5',
-    target: '6',
-    id: '5-6',
-  },
-];
+  const handleNodePointOver = (event) => {
+    setSelections(nodePredecessors[event.id]);
+  };
 
-const Graph = () => {
   return (
     <div>
-      <GraphCanvas nodes={dummyNodes} edges={dummyEdges} />
+      <GraphCanvas
+        nodes={nodes}
+        edges={edges}
+        layoutType="treeLr2d"
+        selections={selections}
+        onNodeClick={(event) => handleNodeClick(event.id)}
+        onNodePointerOver={(event) => handleNodePointOver(event)}
+        onNodePointerOut={() => setSelections([])}
+        labelType="nodes"
+      />
     </div>
   );
 };

--- a/src/pages/curriculums/[id].js
+++ b/src/pages/curriculums/[id].js
@@ -1,25 +1,23 @@
 import React from 'react';
 import { useRouter } from 'next/router';
-import dynamic from 'next/dynamic';
+
 import LearningUnitsSection from '@components/learning-units-section/learning-units-section/LearningUnitsSection';
 import { Skeleton } from 'primereact/skeleton';
 import { TabView, TabPanel } from 'primereact/tabview';
-
-const Graph = dynamic(
-  () => import('@components/learning-units-section/Graph/Graph'),
-  {
-    ssr: false,
-  }
-);
+import GraphSection from '@components/learning-units-section/graph-section/GraphSection';
 
 function CurriculumPage() {
-  const { query, isReady } = useRouter();
+  const router = useRouter();
+  const { query, isReady } = router;
 
   if (!isReady)
     return <Skeleton shape="rectangle" width="100%" height="100%" />;
 
   const curriculumId = query.id;
 
+  const handleLearningUnitClick = (id) => {
+    router.push(`/learning-units/${id}`);
+  };
   return (
     <TabView>
       <TabPanel header="Lista Learning Units">
@@ -35,7 +33,10 @@ function CurriculumPage() {
               position: 'relative',
             }}
           >
-            <Graph />
+            <GraphSection
+              cycleId={1}
+              handleNodeClick={(id) => handleLearningUnitClick(id)}
+            />
           </div>
         </div>
       </TabPanel>

--- a/src/utils/endpoints.js
+++ b/src/utils/endpoints.js
@@ -5,6 +5,9 @@ export const endpoints = (operationId, param) => {
   const endpointsList = {
     curriculum: apiBaseUrl + `/curriculums/${param}`,
     learningUnit: apiBaseUrl + `/learning_units/${param}`,
+    learningUnitSuccessions:
+      apiBaseUrl + `/cycles/${param}/learning_unit_successions`,
+    learningUnitsOfCycle: apiBaseUrl + `/cycles/${param}/learning_units`,
     resource: apiBaseUrl + `/resources/${param}`,
     curriculumLearningUnits:
       apiBaseUrl + `/curriculums/${param}/learning_units`,


### PR DESCRIPTION
# Context
**With this PR, we are enhancing the cycle graph with the following features:**
- Graph nodes are now clickable. They redirect you to the corresponding learning unit page.
- When you hover over a node, all the path leading to this node is highlighted.
- Graph now uses the data of the nodes and edges that it receives from the backend.

# Changelog
- Curriculum page now renders GraphSection component instead of Graph component.
- Create GraphSection component, which asks the backend for the data of the nodes and successions and pass it to the Graph component.
- GraphSection also prepares the nodePredecessors object, which contains, for each node, all the nodes and successions necessary to get to it.
- New endpoints developed in the back are set in the endpoints util.
- Graph component allows nodes to be clickable and to redirect to the corresponding learning unit page, and also hoverable, which highlights the path that leads to this learning unit.

# QA
- Have the backend repository up-to-date and run any needed migrations.
- Run the project in your local environment.
- Open the [page of the curriculum](http://localhost:3001/curriculums/1).
- Go to the graph tab and try the previous mentioned functionalities.