### PR TITLE
Redirect after sign-in

### DIFF
--- a/src/components/layout/Navbar.js
+++ b/src/components/layout/Navbar.js
@@ -46,7 +46,7 @@ function Navbar() {
       );
     } else {
       return (
-        <Link href="/users/sign_in">
+        <Link href={'/users/sign_in?redirect_to=' + router.asPath}>
           <Button label="Sign In" icon="pi pi-power-on" />
         </Link>
       );

--- a/src/components/login-dialog/loginDialog.js
+++ b/src/components/login-dialog/loginDialog.js
@@ -9,7 +9,12 @@ export const LoginDialog = () => {
   const router = useRouter();
   const footer = () => {
     return (
-      <Button label="Ingresar" onClick={() => router.push('/users/sign_in')} />
+      <Button
+        label="Ingresar"
+        onClick={() =>
+          router.push('/users/sign_in?redirect_to=' + router.asPath)
+        }
+      />
     );
   };
 


### PR DESCRIPTION
# Context

With this PR, we are redirecting the user to the page she was visiting before signing-in.

If a user who is not signed-in is visiting a page, for example: `/learning-units/2`, and she decides to sign in from this page (using the Sign-in button in the Navbar), she will be redirected to the sign-in page and, after a successful login, she will be redirected back to the page `/learning-units/2`

# Changelog
- `Navbar` and `LoginDialog` components were modified to add the `redirect_to` param.

# QA
- Run docker container of the Rails app
- Run the frontend server
- You should be logged out
- go to `http://localhost:3001/learning-units/3` and sign-in using the button in the navbar.
- You should be automatically redirected to page `http://localhost:3001/learning-units/3` after sign-in
