### PR TITLE
feat(cycle-view): create cycle view page that displays basic cycle info

### DIFF
--- a/src/components/common/BreadCrumb.js
+++ b/src/components/common/BreadCrumb.js
@@ -1,0 +1,16 @@
+import { BreadCrumb } from 'primereact/breadcrumb';
+import styles from './BreadCrumb.module.scss'
+
+export const CycleBreadCrumb = ({ cycle }) => {
+  const items = [
+    { label: 'Curriculum', url: '/curriculums/1' },
+    { label: cycle.name }
+  ];
+
+  const home = { icon: 'pi pi-home', url: '/' }
+
+  return <BreadCrumb
+    className={styles.cycleBreadCrumb}
+    model={items}
+    home={home}/>
+}

--- a/src/components/common/BreadCrumb.js
+++ b/src/components/common/BreadCrumb.js
@@ -1,16 +1,15 @@
 import { BreadCrumb } from 'primereact/breadcrumb';
-import styles from './BreadCrumb.module.scss'
+import styles from './BreadCrumb.module.scss';
 
 export const CycleBreadCrumb = ({ cycle }) => {
   const items = [
     { label: 'Curriculum', url: '/curriculums/1' },
-    { label: cycle.name }
+    { label: cycle.name },
   ];
 
-  const home = { icon: 'pi pi-home', url: '/' }
+  const home = { icon: 'pi pi-home', url: '/' };
 
-  return <BreadCrumb
-    className={styles.cycleBreadCrumb}
-    model={items}
-    home={home}/>
-}
+  return (
+    <BreadCrumb className={styles.cycleBreadCrumb} model={items} home={home} />
+  );
+};

--- a/src/components/common/BreadCrumb.module.scss
+++ b/src/components/common/BreadCrumb.module.scss
@@ -1,0 +1,3 @@
+.cycleBreadCrumb {
+  margin-bottom: 2vh;
+}

--- a/src/components/cycle-section/cycle-section/ChallengeCard.js
+++ b/src/components/cycle-section/cycle-section/ChallengeCard.js
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import Link from 'next/link';
 import { Card } from 'primereact/card';
 import { ScrollPanel } from 'primereact/scrollpanel';
 import styles from './CycleSection.module.scss';
@@ -6,15 +6,16 @@ import { Accordion, AccordionTab } from 'primereact/accordion';
 
 const ChallengeCard = ({ cycle }) => {
   return (
-    <Card className={`${styles.cycleSectionCard} ${styles.challengeCard}`} title="Desafío">
-      <ScrollPanel className={styles.scrollPanel} >
+    <Card
+      className={`${styles.cycleSectionCard} ${styles.challengeCard}`}
+      title="Desafío"
+    >
+      <ScrollPanel className={styles.scrollPanel}>
         {cycle.challenge_description}
       </ScrollPanel>
       <Accordion className={styles.accordionHeader}>
-        <AccordionTab header="Repositorio base" >
-          <Link href={cycle.boilerplate_url}>
-            <a>Repositorio en GitHub</a>
-          </Link>
+        <AccordionTab header="Repositorio base">
+          <Link href={cycle.boilerplate_url}>Repositorio en GitHub</Link>
         </AccordionTab>
       </Accordion>
     </Card>

--- a/src/components/cycle-section/cycle-section/ChallengeCard.js
+++ b/src/components/cycle-section/cycle-section/ChallengeCard.js
@@ -1,0 +1,24 @@
+import Link from "next/link";
+import { Card } from 'primereact/card';
+import { ScrollPanel } from 'primereact/scrollpanel';
+import styles from './CycleSection.module.scss';
+import { Accordion, AccordionTab } from 'primereact/accordion';
+
+const ChallengeCard = ({ cycle }) => {
+  return (
+    <Card className={`${styles.cycleSectionCard} ${styles.challengeCard}`} title="Desafío">
+      <ScrollPanel className={styles.scrollPanel} >
+        {cycle.challenge_description}
+      </ScrollPanel>
+      <Accordion className={styles.accordionHeader}>
+        <AccordionTab header="Repositorio base" >
+          <Link href={cycle.boilerplate_url}>
+            <a>Repositorio en GitHub</a>
+          </Link>
+        </AccordionTab>
+      </Accordion>
+    </Card>
+  );
+};
+
+export default ChallengeCard;

--- a/src/components/cycle-section/cycle-section/CycleInfoCard.js
+++ b/src/components/cycle-section/cycle-section/CycleInfoCard.js
@@ -1,0 +1,13 @@
+import { Card } from 'primereact/card';
+import styles from './CycleSection.module.scss';
+ 
+
+const CycleInfoCard = ({ cycle }) => {
+  return (
+    <Card className={styles.cycleSectionCard} title="Objetivos de aprendizaje">
+      <p>{cycle.learning_goals_description}</p>
+    </Card>
+  );
+};
+
+export default CycleInfoCard

--- a/src/components/cycle-section/cycle-section/CycleInfoCard.js
+++ b/src/components/cycle-section/cycle-section/CycleInfoCard.js
@@ -1,6 +1,5 @@
 import { Card } from 'primereact/card';
 import styles from './CycleSection.module.scss';
- 
 
 const CycleInfoCard = ({ cycle }) => {
   return (
@@ -10,4 +9,4 @@ const CycleInfoCard = ({ cycle }) => {
   );
 };
 
-export default CycleInfoCard
+export default CycleInfoCard;

--- a/src/components/cycle-section/cycle-section/CycleSection.js
+++ b/src/components/cycle-section/cycle-section/CycleSection.js
@@ -1,4 +1,4 @@
-import Head from 'next/head'
+import Head from 'next/head';
 import styles from './CycleSection.module.scss';
 import CycleInfoCard from '@components/cycle-section/cycle-section/CycleInfoCard';
 import ChallengeCard from './ChallengeCard';
@@ -9,7 +9,6 @@ import useGet from '@hooks/useGet';
 import { endpoints } from '@utils/endpoints';
 import { Skeleton } from 'primereact/skeleton';
 import { Panel } from 'primereact/panel';
-
 
 const CycleSection = ({ cycleId }) => {
   const {
@@ -34,18 +33,18 @@ const CycleSection = ({ cycleId }) => {
     <>
       <Head>
         <title>{cycle.name}</title>
-        <meta property="og:title" content={cycle.name} key="title"/>
+        <meta property="og:title" content={cycle.name} key="title" />
       </Head>
       <CycleBreadCrumb cycle={cycle} />
       <Panel>
         <div className={styles.panelContainer}>
           <CycleTopContainer cycle={cycle} />
           <div className={styles.middleContainer}>
-            <CycleInfoCard cycle={cycle}/>
-            <ChallengeCard cycle={cycle}/>
+            <CycleInfoCard cycle={cycle} />
+            <ChallengeCard cycle={cycle} />
           </div>
           <div className={styles.bottomContainer}>
-            <LearningUnitsCard cycle={cycle} learningUnits={learningUnits}/>
+            <LearningUnitsCard cycle={cycle} learningUnits={learningUnits} />
           </div>
         </div>
       </Panel>

--- a/src/components/cycle-section/cycle-section/CycleSection.js
+++ b/src/components/cycle-section/cycle-section/CycleSection.js
@@ -1,0 +1,56 @@
+import Head from 'next/head'
+import styles from './CycleSection.module.scss';
+import CycleInfoCard from '@components/cycle-section/cycle-section/CycleInfoCard';
+import ChallengeCard from './ChallengeCard';
+import LearningUnitsCard from './LearningUnitsCard';
+import { CycleTopContainer } from './CycleTopContainer';
+import { CycleBreadCrumb } from '@components/common/BreadCrumb';
+import useGet from '@hooks/useGet';
+import { endpoints } from '@utils/endpoints';
+import { Skeleton } from 'primereact/skeleton';
+import { Panel } from 'primereact/panel';
+
+
+const CycleSection = ({ cycleId }) => {
+  const {
+    data: learningUnits,
+    isLoading: isLoadingUnits,
+    isError: isErrorUnit,
+  } = useGet(endpoints('cycleLearningUnits', cycleId));
+  const {
+    data: cycle,
+    isLoading: isLoadingCurriculum,
+    isError: isErrorCurriculum,
+  } = useGet(endpoints('cycle', cycleId));
+
+  if (isLoadingUnits || isLoadingCurriculum) {
+    return <Skeleton shape="rectangle" width="100%" height="100%" />;
+  }
+  if (isErrorUnit || isErrorCurriculum) {
+    return 'error';
+  }
+
+  return (
+    <>
+      <Head>
+        <title>{cycle.name}</title>
+        <meta property="og:title" content={cycle.name} key="title"/>
+      </Head>
+      <CycleBreadCrumb cycle={cycle} />
+      <Panel>
+        <div className={styles.panelContainer}>
+          <CycleTopContainer cycle={cycle} />
+          <div className={styles.middleContainer}>
+            <CycleInfoCard cycle={cycle}/>
+            <ChallengeCard cycle={cycle}/>
+          </div>
+          <div className={styles.bottomContainer}>
+            <LearningUnitsCard cycle={cycle} learningUnits={learningUnits}/>
+          </div>
+        </div>
+      </Panel>
+    </>
+  );
+};
+
+export default CycleSection;

--- a/src/components/cycle-section/cycle-section/CycleSection.js
+++ b/src/components/cycle-section/cycle-section/CycleSection.js
@@ -3,6 +3,7 @@ import styles from './CycleSection.module.scss';
 import CycleInfoCard from '@components/cycle-section/cycle-section/CycleInfoCard';
 import ChallengeCard from './ChallengeCard';
 import LearningUnitsCard from './LearningUnitsCard';
+import Error from './error';
 import { CycleTopContainer } from './CycleTopContainer';
 import { CycleBreadCrumb } from '@components/common/BreadCrumb';
 import useGet from '@hooks/useGet';
@@ -14,20 +15,21 @@ const CycleSection = ({ cycleId }) => {
   const {
     data: learningUnits,
     isLoading: isLoadingUnits,
-    isError: isErrorUnit,
+    isError: isErrorUnits,
+    mutate: mutateUnits,
   } = useGet(endpoints('cycleLearningUnits', cycleId));
   const {
     data: cycle,
     isLoading: isLoadingCurriculum,
     isError: isErrorCurriculum,
+    mutate: mutateCurriculum,
   } = useGet(endpoints('cycle', cycleId));
 
   if (isLoadingUnits || isLoadingCurriculum) {
     return <Skeleton shape="rectangle" width="100%" height="100%" />;
   }
-  if (isErrorUnit || isErrorCurriculum) {
-    return 'error';
-  }
+  if (isErrorUnits) return <Error reset={mutateUnits} />;
+  if (isErrorCurriculum) return <Error reset={mutateCurriculum} />;
 
   return (
     <>

--- a/src/components/cycle-section/cycle-section/CycleSection.module.scss
+++ b/src/components/cycle-section/cycle-section/CycleSection.module.scss
@@ -1,3 +1,8 @@
+$black: #000000;
+$white: #f3f3f3;
+$grey: #eff1ff;
+$blue: #37368f;
+
 .panelContainer {
   display: flex;
   flex-direction: column;
@@ -45,12 +50,12 @@
 }
 
 .challengeCard {
-  color: #ffffff;
-  background-color: #eda039;
+  color: $black;
+  background-color: $white;
 }
 
 .scrollPanel .p-scrollpanel-wrapper {
-  border-right: 9px solid #f4f4f4;
+  border-right: 9px solid $white;
 }
 
 .scrollPanel .p-scrollpanel-bar {
@@ -71,18 +76,18 @@
   & > [class~='p-accordion-tab'] {
     & > [class~='p-accordion-header'] {
       & > [class~='p-accordion-header-link'] {
-        background-color: #eac545;
-        color: #000000;
+        background-color: $blue;
+        color: $white;
         &:hover {
-          background-color: #eac545 !important;
-          color: #ffffff !important;
+          background-color: $blue !important;
+          color: $white !important;
         }
       }
     }
 
     & > [class~='p-toggleable-content'] {
       & > [class~='p-accordion-content'] {
-        background-color: #eac545;
+        background-color: $grey;
       }
     }
   }
@@ -90,22 +95,15 @@
   & > [class~='p-accordion-tab-active'] {
     & > [class~='p-highlight'] {
       & > [class~='p-accordion-header-link'] {
-        background-color: #eac545 !important;
+        background-color: $blue !important;
+        color: $white !important;
       }
     }
   }
 }
 
-.cycleCompletitionButton {
-  background-color: #f3c067;
-  color: #000000;
-  &:hover {
-    background-color: #eac545 !important;
-  }
-}
-
 .learningUnitsCard {
   flex: 1;
-  background-color: #000000;
-  color: #ffffff;
+  background-color: $grey;
+  color: $black;
 }

--- a/src/components/cycle-section/cycle-section/CycleSection.module.scss
+++ b/src/components/cycle-section/cycle-section/CycleSection.module.scss
@@ -1,0 +1,111 @@
+.panelContainer {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  align-content: center;
+  width: 96vw;
+}
+
+.topContainer {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: start;
+  align-content: center;
+  width: 96vw;
+  padding: 1vw;
+}
+
+.middleContainer {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+  gap: 4vw;
+  align-content: center;
+  width: 96vw;
+  padding: 1vw;
+}
+
+.bottomContainer {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+  align-content: center;
+  width: 96vw;
+  padding: 1vw;
+}
+
+.breadCrumbs {
+  float: left;
+}
+
+.cycleSectionCard {
+  flex: 1;
+}
+
+.challengeCard {
+  color: #ffffff;
+  background-color: #eda039;
+}
+
+.scrollPanel .p-scrollpanel-wrapper {
+  border-right: 9px solid #f4f4f4;
+}
+
+.scrollPanel .p-scrollpanel-bar {
+  background-color: #1976d2;
+  opacity: 1;
+  transition: background-color 0.3s;
+}
+
+.scrollPanel .p-scrollpanel-bar:hover {
+  background-color: #135ba1;
+}
+
+.scrollPanel {
+  height: 30vh;
+}
+
+.accordionHeader {
+  & > [class~='p-accordion-tab'] {
+    & > [class~='p-accordion-header'] {
+      & > [class~='p-accordion-header-link'] {
+        background-color: #eac545;
+        color: #000000;
+        &:hover {
+          background-color: #eac545 !important;
+          color: #ffffff !important;
+        }
+      }
+    }
+
+    & > [class~='p-toggleable-content'] {
+      & > [class~='p-accordion-content'] {
+        background-color: #eac545;
+      }
+    }
+  }
+
+  & > [class~='p-accordion-tab-active'] {
+    & > [class~='p-highlight'] {
+      & > [class~='p-accordion-header-link'] {
+        background-color: #eac545 !important;
+      }
+    }
+  }
+}
+
+.cycleCompletitionButton {
+  background-color: #f3c067;
+  color: #000000;
+  &:hover {
+    background-color: #eac545 !important;
+  }
+}
+
+.learningUnitsCard {
+  flex: 1;
+  background-color: #000000;
+  color: #ffffff;
+}

--- a/src/components/cycle-section/cycle-section/CycleTopContainer.js
+++ b/src/components/cycle-section/cycle-section/CycleTopContainer.js
@@ -1,17 +1,12 @@
-import styles from './CycleSection.module.scss'
-import { Button } from 'primereact/Button';
+import styles from './CycleSection.module.scss';
 
 export const CycleTopContainer = ({ cycle }) => {
-
   return (
     <div className={styles.topContainer}>
       <div>
         <h2>Ciclo {cycle.order_number}</h2>
         <h1>{cycle.name}</h1>
       </div>
-      <div>
-        <Button className={styles.cycleCompletitionButton}label="Completar ciclo"/>
-      </div>
     </div>
-);
+  );
 };

--- a/src/components/cycle-section/cycle-section/CycleTopContainer.js
+++ b/src/components/cycle-section/cycle-section/CycleTopContainer.js
@@ -1,0 +1,17 @@
+import styles from './CycleSection.module.scss'
+import { Button } from 'primereact/Button';
+
+export const CycleTopContainer = ({ cycle }) => {
+
+  return (
+    <div className={styles.topContainer}>
+      <div>
+        <h2>Ciclo {cycle.order_number}</h2>
+        <h1>{cycle.name}</h1>
+      </div>
+      <div>
+        <Button className={styles.cycleCompletitionButton}label="Completar ciclo"/>
+      </div>
+    </div>
+);
+};

--- a/src/components/cycle-section/cycle-section/LearningUnitsCard.js
+++ b/src/components/cycle-section/cycle-section/LearningUnitsCard.js
@@ -1,0 +1,14 @@
+import { Card } from 'primereact/card';
+import styles from './CycleSection.module.scss';
+
+const LearningUnitsCard = ({ cycle, learningUnits }) => {
+  return (
+    <Card className={styles.learningUnitsCard} title="Learning units">
+      <ul>
+        {learningUnits.map(lu => (<li key={lu.id}>{lu.name}</li>))}
+      </ul>
+    </Card>
+  );
+};
+
+export default LearningUnitsCard;

--- a/src/components/cycle-section/cycle-section/LearningUnitsCard.js
+++ b/src/components/cycle-section/cycle-section/LearningUnitsCard.js
@@ -1,11 +1,16 @@
 import { Card } from 'primereact/card';
 import styles from './CycleSection.module.scss';
+import Link from 'next/link';
 
-const LearningUnitsCard = ({ cycle, learningUnits }) => {
+const LearningUnitsCard = ({ learningUnits }) => {
   return (
     <Card className={styles.learningUnitsCard} title="Learning units">
       <ul>
-        {learningUnits.map(lu => (<li key={lu.id}>{lu.name}</li>))}
+        {learningUnits.map((lu) => (
+          <li key={lu.id}>
+            <Link href={'/learning-units/' + lu.id}>{lu.name}</Link>
+          </li>
+        ))}
       </ul>
     </Card>
   );

--- a/src/components/cycle-section/cycle-section/error.js
+++ b/src/components/cycle-section/cycle-section/error.js
@@ -1,0 +1,16 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function Error({ error, reset }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div>
+      <p>¡Ocurrió un error!</p>
+      <button onClick={() => reset()}>Inténtalo otra vez</button>
+    </div>
+  );
+}

--- a/src/pages/cycles/[id].js
+++ b/src/pages/cycles/[id].js
@@ -11,15 +11,15 @@ const CyclePage = () => {
 
   const cycleId = query.id;
 
-  if (process.env.NODE_ENV === 'development'){
+  if (process.env.NODE_ENV === 'development') {
     return (
       <>
-        <CycleSection cycleId={cycleId}/>
+        <CycleSection cycleId={cycleId} />
       </>
-      );
-    } else {
-      return <p>WIP</p>
-    }
-}
+    );
+  } else {
+    return <p>WIP</p>;
+  }
+};
 
 export default CyclePage;

--- a/src/pages/cycles/[id].js
+++ b/src/pages/cycles/[id].js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { useRouter } from 'next/router';
+import CycleSection from '@components/cycle-section/cycle-section/CycleSection';
+import { Skeleton } from 'primereact/skeleton';
+
+const CyclePage = () => {
+  const { query, isReady } = useRouter();
+
+  if (!isReady)
+    return <Skeleton shape="rectangle" width="100%" height="100%" />;
+
+  const cycleId = query.id;
+
+  if (process.env.NODE_ENV === 'development'){
+    return (
+      <>
+        <CycleSection cycleId={cycleId}/>
+      </>
+      );
+    } else {
+      return <p>WIP</p>
+    }
+}
+
+export default CyclePage;

--- a/src/utils/endpoints.js
+++ b/src/utils/endpoints.js
@@ -13,8 +13,7 @@ export const endpoints = (operationId, param) => {
     resource: apiBaseUrl + `/resources/${param}`,
     curriculumLearningUnits:
       apiBaseUrl + `/curriculums/${param}/learning_units`,
-    cycleLearningUnits:
-      apiBaseUrl + `/cycles/${param}/learning_units`,
+    cycleLearningUnits: apiBaseUrl + `/cycles/${param}/learning_units`,
     isLearningUnitCompleted: apiBaseUrl + `/learning_units/${param}/completed`,
     learningUnitResources: apiBaseUrl + `/learning_units/${param}/resources`,
     resourceEvaluation: apiBaseUrl + `/resources/${param}/evaluation`,

--- a/src/utils/endpoints.js
+++ b/src/utils/endpoints.js
@@ -4,6 +4,7 @@ export const endpoints = (operationId, param) => {
 
   const endpointsList = {
     curriculum: apiBaseUrl + `/curriculums/${param}`,
+    cycle: apiBaseUrl + `/cycles/${param}`,
     learningUnit: apiBaseUrl + `/learning_units/${param}`,
     learningUnitSuccessions:
       apiBaseUrl + `/cycles/${param}/learning_unit_successions`,
@@ -12,6 +13,8 @@ export const endpoints = (operationId, param) => {
     resource: apiBaseUrl + `/resources/${param}`,
     curriculumLearningUnits:
       apiBaseUrl + `/curriculums/${param}/learning_units`,
+    cycleLearningUnits:
+      apiBaseUrl + `/cycles/${param}/learning_units`,
     isLearningUnitCompleted: apiBaseUrl + `/learning_units/${param}/completed`,
     learningUnitResources: apiBaseUrl + `/learning_units/${param}/resources`,
     resourceEvaluation: apiBaseUrl + `/resources/${param}/evaluation`,


### PR DESCRIPTION
# Note
This PR only creates a new view, which is not displayed in production and has no links that access this page
# Context
With this PR, we are creating a cycle view which is supposed to be an intermediate page between curriculum and learning_unit. 
The cycle view must display the cycle info, a dummy button to complete the cycle, the challenge and it's boilerplate repo and a list of learning_units that it contains.
A subsequent PR should include a view of the learning_units displayed as a directed graph, another one should implement the functionality of the complete button after the models are created in the backend, and a third one should implement the functionality to add a user's GitHub repository link in the corresponding accordion tab.

# Changelog
Create cycle[id] page
Create BreadCrumb component in the Common directory
Create BreadCrumb styles module in the Common directory
Create cycle-section directory
Create CycleSection component
Create CycleSection styles module
Create CyclePanel component
Create CycleTopContainer component
Create CycleInfoCard component
Create ChallengeCard component
Create LearningUnitsCard component

# QA
Run docker container of the Rails app
Run the frontend server
go to http://localhost:3001/cycles/1
You should be able to see a cycle's page with all it's info, including an accordion which displays the boilerplate repository and a breadcrumb on top that links to it's curriculum and home page.