### PR TITLE
Update eslint.yml to accept legacy peer deps as yarn does

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install ESLint
         run: |
-          npm install --force eslint@8.23.1 
+          npm install --force --legacy-peer-deps eslint@8.23.1 
           npm install @microsoft/eslint-formatter-sarif@2.1.7
 
       - name: Run ESLint


### PR DESCRIPTION
### Context
The ESLINT Github Action installs eslint and the project dependencies. However, it uses npm to solve the dependencies and not yarn. By default, npm is less permissive with legacy dependencies than yarn. To solve this, the --legacy-peer-deps flag is added to npm command.

