### PR TITLE
Update eslint.yml

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -32,8 +32,8 @@ jobs:
 
       - name: Install ESLint
         run: |
-          yarn eslint@8.23.1 
-          yarn @microsoft/eslint-formatter-sarif@2.1.7
+          yarn install eslint@8.23.1 
+          yarn install @microsoft/eslint-formatter-sarif@2.1.7
 
       - name: Run ESLint
         run: npx eslint .

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -32,8 +32,8 @@ jobs:
 
       - name: Install ESLint
         run: |
-          yarn install eslint@8.23.1 
-          yarn install @microsoft/eslint-formatter-sarif@2.1.7
+          yarn add eslint@8.23.1 
+          yarn add @microsoft/eslint-formatter-sarif@2.1.7
 
       - name: Run ESLint
         run: npx eslint .

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -32,8 +32,8 @@ jobs:
 
       - name: Install ESLint
         run: |
-          npm install --force --legacy-peer-deps eslint@8.23.1 
-          npm install @microsoft/eslint-formatter-sarif@2.1.7
+          yarn eslint@8.23.1 
+          yarn @microsoft/eslint-formatter-sarif@2.1.7
 
       - name: Run ESLint
         run: npx eslint .


### PR DESCRIPTION
Context
The ESLINT Github Action installs eslint and the project dependencies. However, it uses npm to solve the dependencies and not yarn. By default, npm is less permissive with legacy dependencies than yarn. To solve this, the --legacy-peer-deps flag is added to npm command. However, it didn't work. As final solution, we decided to replace npm with yarn.