### PR TITLE
Add new resource button no auth

### DIFF
--- a/src/components/resources-section/add-new-resource-button/addNewResourceButton.js
+++ b/src/components/resources-section/add-new-resource-button/addNewResourceButton.js
@@ -1,0 +1,30 @@
+import useCurrentUser from '@hooks/useCurrentUser';
+import useLoginDialog from '@hooks/useLoginDialog';
+import { Button } from 'primereact/button';
+
+const AddNewResourceButton = ({ setDisplayBasic }) => {
+  const currentUser = useCurrentUser();
+  const loginDialog = useLoginDialog();
+
+  if (currentUser) {
+    return <Button icon="pi pi-plus" onClick={() => setDisplayBasic(true)} />;
+  }
+
+  return (
+    <div
+      onClick={() => loginDialog.setDisplayLoginDialog(true)}
+      onKeyPress={null}
+      role="button"
+      tabIndex="0"
+    >
+      <Button
+        icon="pi pi-plus"
+        disabled
+        tooltip="Ingresa para agregar un recurso"
+        tooltipOptions={{ showOnDisabled: true, position: 'left' }}
+      />
+    </div>
+  );
+};
+
+export default AddNewResourceButton;

--- a/src/components/resources-section/resources-section/ResourcesSection.js
+++ b/src/components/resources-section/resources-section/ResourcesSection.js
@@ -10,12 +10,17 @@ import LearningUnitInformation from '@components/resources-section/learning-unit
 import ResourcesScroller from '../resources-scroller/ResourcesScroller';
 import ResourceSection from '@components/resource-section/resource-section/ResourceSection';
 import styles from './ResourcesSection.module.scss';
+import useLoginDialog from '@hooks/useLoginDialog';
+import useCurrentUser from '@hooks/useCurrentUser';
+import { LoginDialog } from '@components/login-dialog/loginDialog';
 
 const ResourcesSection = ({ learningUnitId }) => {
   const router = useRouter();
   const [displayBasic, setDisplayBasic] = useState(false);
   const [sidebarVisible, setSidebarVisible] = useState(false);
   const [activeResource, setActiveResource] = useState(null);
+  const currentUser = useCurrentUser();
+  const loginDialog = useLoginDialog();
 
   const {
     data: learningUnit,
@@ -67,6 +72,28 @@ const ResourcesSection = ({ learningUnitId }) => {
     setSidebarVisible(true);
   };
 
+  const addNewResourceButton = () => {
+    if (currentUser) {
+      return <Button icon="pi pi-plus" onClick={() => setDisplayBasic(true)} />;
+    }
+
+    return (
+      <div
+        onClick={() => loginDialog.setDisplayLoginDialog(true)}
+        onKeyPress={null}
+        role="button"
+        tabIndex="0"
+      >
+        <Button
+          icon="pi pi-plus"
+          disabled
+          tooltip="Ingresa para agregar un recurso"
+          tooltipOptions={{ showOnDisabled: true, position: 'left' }}
+        />
+      </div>
+    );
+  };
+
   const header = () => {
     return (
       <div className={styles.resourceHeader}>
@@ -77,7 +104,7 @@ const ResourcesSection = ({ learningUnitId }) => {
             icon="pi pi-arrow-left"
             onClick={() => router.back()}
           />
-          <Button icon="pi pi-plus" onClick={() => setDisplayBasic(true)} />
+          {addNewResourceButton()}
         </div>
       </div>
     );
@@ -87,6 +114,7 @@ const ResourcesSection = ({ learningUnitId }) => {
     <div className={styles.container}>
       <Panel header={header}>
         <LearningUnitInformation learningUnit={learningUnit} />
+        <LoginDialog />
         {displayBasic && (
           <AddNewResourceModal
             handlers={modalHandlers}

--- a/src/components/resources-section/resources-section/ResourcesSection.js
+++ b/src/components/resources-section/resources-section/ResourcesSection.js
@@ -10,17 +10,14 @@ import LearningUnitInformation from '@components/resources-section/learning-unit
 import ResourcesScroller from '../resources-scroller/ResourcesScroller';
 import ResourceSection from '@components/resource-section/resource-section/ResourceSection';
 import styles from './ResourcesSection.module.scss';
-import useLoginDialog from '@hooks/useLoginDialog';
-import useCurrentUser from '@hooks/useCurrentUser';
 import { LoginDialog } from '@components/login-dialog/loginDialog';
+import AddNewResourceButton from '../add-new-resource-button/addNewResourceButton';
 
 const ResourcesSection = ({ learningUnitId }) => {
   const router = useRouter();
   const [displayBasic, setDisplayBasic] = useState(false);
   const [sidebarVisible, setSidebarVisible] = useState(false);
   const [activeResource, setActiveResource] = useState(null);
-  const currentUser = useCurrentUser();
-  const loginDialog = useLoginDialog();
 
   const {
     data: learningUnit,
@@ -72,28 +69,6 @@ const ResourcesSection = ({ learningUnitId }) => {
     setSidebarVisible(true);
   };
 
-  const addNewResourceButton = () => {
-    if (currentUser) {
-      return <Button icon="pi pi-plus" onClick={() => setDisplayBasic(true)} />;
-    }
-
-    return (
-      <div
-        onClick={() => loginDialog.setDisplayLoginDialog(true)}
-        onKeyPress={null}
-        role="button"
-        tabIndex="0"
-      >
-        <Button
-          icon="pi pi-plus"
-          disabled
-          tooltip="Ingresa para agregar un recurso"
-          tooltipOptions={{ showOnDisabled: true, position: 'left' }}
-        />
-      </div>
-    );
-  };
-
   const header = () => {
     return (
       <div className={styles.resourceHeader}>
@@ -104,7 +79,7 @@ const ResourcesSection = ({ learningUnitId }) => {
             icon="pi pi-arrow-left"
             onClick={() => router.back()}
           />
-          {addNewResourceButton()}
+          <AddNewResourceButton setDisplayBasic={setDisplayBasic} />
         </div>
       </div>
     );


### PR DESCRIPTION
# Context

With this PR we are changing the behavior of the add new resource button ("+") in the learning unit page to handle the case when the user is not authenticated.  In this case, the button is disabled, it shows a tooltip message when the mouse pass over the button and open a modal inviting to join to ser.dev if clicked. When user is authenticated, the same behavior as before remains, this is, open a modal with a modal to add a new resource.

# Change log

* Create [addNewResourceButton.js](https://github.com/fintual-oss/paraffin-front/compare/feat/unauth_lu_page?expand=1#diff-05c52e90f9aa107765c27c5c03d1236f0e1eb4109003f34a914416e89442788e) component to better organize the button behavior.
* modify [ResourcesSection.js](https://github.com/fintual-oss/paraffin-front/compare/feat/unauth_lu_page?expand=1#diff-6d2851d6b55dd1348a4922fcf22170bbc94750d195c629799aee2825da14d1ad) to move the add new resource functions to the `addNewResourceButton` component.

# QA

1. Logout
2. go to http://localhost:3001/learning-units/1
3. Button "+" (in the top right) should be disabled. When pass mouse over, it shows the message "Ingresa para agregar un recurso". If you make click on the button, a modal inviting you to join ser.dev should be displayed.
4. Login with an user
5. go to http://localhost:3001/learning-units/1
6. Make click on button "+", a modal with a form to add a new resource should be displayed.
7. Fill the form and check the new resource is created.