### PR TITLE
Feature: display resource labels 

### DIFF
--- a/src/components/resources-section/resource-labels/ResourceLabels.js
+++ b/src/components/resources-section/resource-labels/ResourceLabels.js
@@ -1,0 +1,34 @@
+import { Button } from 'primereact/button';
+import icons from '@utils/icons';
+import styles from './ResourceLabels.module.scss';
+
+const DisplayLabel = ({ label }) => (
+  <Button
+    icon={icons(label.name)}
+    className={'p-button-rounded p-button-outline'}
+    tooltip={label.description}
+    iconPos="center"
+    aria-label="Label"
+    disabled
+    tooltipOptions={{ showOnDisabled: true }}
+  />
+);
+
+const ResourceLabels = ({ resourceLabels }) => {
+  console.log(resourceLabels);
+  const hasLabels = resourceLabels.length === 0;
+
+  if (hasLabels) {
+    return;
+  }
+
+  return (
+    <div className={styles.resourceLabels}>
+      {resourceLabels.map((label) => (
+        <DisplayLabel label={label} key={label.id} />
+      ))}
+    </div>
+  );
+};
+
+export default ResourceLabels;

--- a/src/components/resources-section/resource-labels/ResourceLabels.js
+++ b/src/components/resources-section/resource-labels/ResourceLabels.js
@@ -15,12 +15,9 @@ const DisplayLabel = ({ label }) => (
 );
 
 const ResourceLabels = ({ resourceLabels }) => {
-  console.log(resourceLabels);
-  const hasLabels = resourceLabels.length === 0;
+  const hasNoLabels = resourceLabels.length === 0;
 
-  if (hasLabels) {
-    return;
-  }
+  if (hasNoLabels) return;
 
   return (
     <div className={styles.resourceLabels}>

--- a/src/components/resources-section/resource-labels/ResourceLabels.module.scss
+++ b/src/components/resources-section/resource-labels/ResourceLabels.module.scss
@@ -1,0 +1,6 @@
+.resourceLabels {
+  display: flex;
+  margin-top: 0.25rem;
+  gap: 1rem;
+  justify-content: center;
+}

--- a/src/components/resources-section/resources-list-item/ResourcesListItem.js
+++ b/src/components/resources-section/resources-list-item/ResourcesListItem.js
@@ -4,13 +4,21 @@ import styles from './ResourcesListItem.module.scss';
 import Link from 'next/link';
 import Image from 'next/image';
 import profilePic from '@utils/images/resource.jpg';
+import { Tag } from 'primereact/tag';
 
 const ResourcesListItem = ({ resource, resourceViewButtonHandler }) => {
+  const displayTags = () => {
+    if (resource.resource_labels.length > 0) return '';
+    console.log(resource);
+    return <Tag icon={'pi ' + resource.resource_labels.icon}></Tag>;
+  };
+
   return (
     <div>
       <div className={styles.resourceGridItem}>
         <div className={styles.resourceListItem}>
           <Image className={styles.img} src={profilePic} alt={resource.name} />
+          <div>{displayTags()}</div>
           <div>
             <div className={styles.resourceName}>
               <Link href={`/resources/${resource.id}`}>{resource.name}</Link>

--- a/src/components/resources-section/resources-list-item/ResourcesListItem.js
+++ b/src/components/resources-section/resources-list-item/ResourcesListItem.js
@@ -4,25 +4,19 @@ import styles from './ResourcesListItem.module.scss';
 import Link from 'next/link';
 import Image from 'next/image';
 import profilePic from '@utils/images/resource.jpg';
-import { Tag } from 'primereact/tag';
+import ResourceLabels from '../resource-labels/ResourceLabels';
 
 const ResourcesListItem = ({ resource, resourceViewButtonHandler }) => {
-  const displayTags = () => {
-    if (resource.resource_labels.length > 0) return '';
-    console.log(resource);
-    return <Tag icon={'pi ' + resource.resource_labels.icon}></Tag>;
-  };
-
   return (
     <div>
       <div className={styles.resourceGridItem}>
         <div className={styles.resourceListItem}>
           <Image className={styles.img} src={profilePic} alt={resource.name} />
-          <div>{displayTags()}</div>
           <div>
             <div className={styles.resourceName}>
               <Link href={`/resources/${resource.id}`}>{resource.name}</Link>
             </div>
+            <ResourceLabels resourceLabels={resource.resource_labels} />
             <div className={styles.resourceValidation}>
               <Average
                 average={parseFloat(resource.average_evaluation).toFixed(1)}

--- a/src/utils/icons.js
+++ b/src/utils/icons.js
@@ -1,0 +1,11 @@
+const icons = (label_name) => {
+  const iconsList = {
+    Paid: 'pi pi-dollar',
+    Article: 'pi pi-book',
+    Media: 'pi pi-video',
+  };
+
+  return iconsList[label_name];
+};
+
+export default icons;


### PR DESCRIPTION
# Base PR
- PR based on main branch.

# Context
- With this PR, we display every label of Learning Unit Resources as an icon with a tooltip with its description. 

# Changelog
- Add new Resource Label component
- Use Resource Label component on Resource List Item
- Add icons utils to manage the transformation from label name to label icon
- Add style for how Labels are displayed in a scss module. 

# QA
- You need to have backend main [main branch](https://github.com/fintual-oss/paraffin-back) working
- This should include **NEW SEEDS**, and could could require to run, on Rails console the following command: 
`rails db:drop db:create db:migrate db:seed`.  
- Launch frontend App (yarn dev) on front project. 
- Go to http://localhost:3001/learning-units/2. It should looks like this: 

![image](https://user-images.githubusercontent.com/12021066/200128726-61c96df3-2e3f-426e-830a-be7a4b4a0f8b.png)



