### PR TITLE
feat(enter-from-landing-without-login): Add button

### DIFF
--- a/src/components/landing/header/Header.js
+++ b/src/components/landing/header/Header.js
@@ -26,15 +26,25 @@ const Header = () => {
             guía y el apoyo de la comunidad lo lograrás!
           </p>
         </Fade>
-        <Fade bottom>
-          <Link href="/users/sign_in">
-            <Button
-              label="Quiero registrarme en Ser.dev"
-              disabled={currentUser}
-              className={`${currentUser ? 'hidden' : ''}`}
-            />
-          </Link>
-        </Fade>
+        <div className="flex gap-4">
+          <Fade bottom>
+            <Link href="/curriculums/1">
+              <Button
+                label={`${currentUser ? 'Quiero seguir estudiando' : 'Quiero entrar sin registrarme'}`}
+                className={`p-button p-component p-button-text`}
+              />
+            </Link>
+          </Fade>
+          <Fade bottom>
+            <Link href="/users/sign_in">
+              <Button
+                label="Quiero registrarme en Ser.dev"
+                disabled={currentUser}
+                className={`${currentUser ? 'hidden' : ''}`}
+              />
+            </Link>
+          </Fade>
+        </div>
       </div>
       <div className={`col-12 md:col-6 xl:col-3 ${styles.header__image}`}>
         <Image src={logo} alt="Logo" id={styles.header__logo} />

--- a/src/components/landing/header/Header.js
+++ b/src/components/landing/header/Header.js
@@ -35,16 +35,20 @@ const Header = () => {
                     ? 'Quiero seguir estudiando'
                     : 'Quiero entrar sin registrarme'
                 }`}
-                className={`p-button p-component p-button-text`}
+                className={`${
+                  currentUser
+                    ? 'p-button p-component'
+                    : 'p-button p-component p-button-text'
+                }`}
               />
             </Link>
           </Fade>
           <Fade bottom>
-            <Link href="/users/sign_in">
+            <Link href="/users/sign_up">
               <Button
                 label="Quiero registrarme en Ser.dev"
                 disabled={currentUser}
-                className={`${currentUser ? 'hidden' : ''}`}
+                className={`${currentUser ? 'hidden' : 'p-button p-component'}`}
               />
             </Link>
           </Fade>

--- a/src/components/landing/header/Header.js
+++ b/src/components/landing/header/Header.js
@@ -30,7 +30,11 @@ const Header = () => {
           <Fade bottom>
             <Link href="/curriculums/1">
               <Button
-                label={`${currentUser ? 'Quiero seguir estudiando' : 'Quiero entrar sin registrarme'}`}
+                label={`${
+                  currentUser
+                    ? 'Quiero seguir estudiando'
+                    : 'Quiero entrar sin registrarme'
+                }`}
                 className={`p-button p-component p-button-text`}
               />
             </Link>


### PR DESCRIPTION
Added a button to enter at curriculums without been login.
<img width="1427" alt="image" src="https://user-images.githubusercontent.com/1480226/200128757-82a680ce-1c81-4411-899b-a109b5f9199d.png">

And when is logged the button change to follow studying
<img width="1436" alt="image" src="https://user-images.githubusercontent.com/1480226/200128803-871f6c88-2272-4533-b08a-12ac85ddaa0d.png">

### QA
- Lunch the front with yarn dev
- Enter in http://localhost:3001/
- Check the button without login and then login to the app 