### PR TITLE
Fix console error in ToggleButton component

### DIFF
--- a/src/components/cycle-section/cycle-section/CompleteCycle.js
+++ b/src/components/cycle-section/cycle-section/CompleteCycle.js
@@ -14,14 +14,15 @@ export const CompleteCycle = ({ cycle, changeHandler, toast }) => {
       <Tooltip target=".thisButton" />
       <span>
         <ToggleButton
-          className="thisButton"
+          className={`thisButton ${
+            cycle.completed || !currentUser ? 'p-disabled' : ''
+          }`}
           onLabel="Completado"
           offLabel="Marcar como completado"
           onIcon="pi pi-verified"
           offIcon="pi pi-verified"
           checked={cycle.completed}
           onChange={changeHandler}
-          disabled={cycle.completed || !currentUser}
           tooltip={tooltip}
           tooltipOptions={{ showOnDisabled: true, position: 'bottom' }}
         />

--- a/src/components/cycle-section/cycle-section/CompleteCycle.js
+++ b/src/components/cycle-section/cycle-section/CompleteCycle.js
@@ -7,16 +7,14 @@ export const CompleteCycle = ({ cycle, changeHandler, toast }) => {
   const currentUser = useCurrentUser();
   const tooltip =
     !currentUser && 'Debes iniciar sesión para registrar tu avance';
-
+  const toggleDisabled = cycle.completed || !currentUser ? 'p-disabled' : '';
   return (
     <div>
       <Toast ref={toast} position="bottom-center" />
-      <Tooltip target=".thisButton" />
+      <Tooltip target=".CompleteCycleToggleButton" />
       <span>
         <ToggleButton
-          className={`thisButton ${
-            cycle.completed || !currentUser ? 'p-disabled' : ''
-          }`}
+          className={`CompleteCycleToggleButton ${toggleDisabled}`}
           onLabel="Completado"
           offLabel="Marcar como completado"
           onIcon="pi pi-verified"


### PR DESCRIPTION
# context
Cycle page is throwing a console error when no user is authenticated, or when authenticated, user mark as completed. This is because `ToggleButton` component from Primefaces doesn't have the `disabled` prop, but instead it's necessary to set the classname `p-disabled`

# before
![image](https://user-images.githubusercontent.com/17869861/200705019-520cd3f8-7ab7-4dc7-811b-0bf73e2e46d7.png)


# After
![image](https://user-images.githubusercontent.com/17869861/200704912-ce3f1778-6334-4b07-b7fb-71b75441e2a1.png)
