### PR TITLE
Fix: adjust sizes of description and challenge on cycle page

### DIFF
--- a/src/components/cycle-section/cycle-section/CycleSection.module.scss
+++ b/src/components/cycle-section/cycle-section/CycleSection.module.scss
@@ -25,10 +25,11 @@ $blue: #37368f;
 .middleContainer {
   display: flex;
   flex-direction: row;
-  justify-content: space-around;
+  justify-content: center;
   gap: 4vw;
   align-content: center;
-  width: 96vw;
+  width: 80vw;
+  height: 20rem;
   padding: 1vw;
 }
 
@@ -47,11 +48,13 @@ $blue: #37368f;
 
 .cycleSectionCard {
   flex: 1;
+  height: 100%;
 }
 
 .challengeCard {
   color: $black;
   background-color: $white;
+  height: 100%
 }
 
 .scrollPanel .p-scrollpanel-wrapper {
@@ -66,10 +69,6 @@ $blue: #37368f;
 
 .scrollPanel .p-scrollpanel-bar:hover {
   background-color: #135ba1;
-}
-
-.scrollPanel {
-  height: 30vh;
 }
 
 .accordionHeader {


### PR DESCRIPTION
Reduce the size of description and challenge card on cycle page.

## Before

<img width="1552" alt="Screen Shot 2022-11-08 at 21 41 57" src="https://user-images.githubusercontent.com/20021589/200708091-8e64901e-0f0c-4406-b7b9-a4be8198a932.png">


## After

<img width="1552" alt="Screen Shot 2022-11-08 at 21 42 22" src="https://user-images.githubusercontent.com/20021589/200708128-d7b5b06e-3f07-4c3f-b33e-732eec9f5530.png">

<img width="612" alt="Screen Shot 2022-11-08 at 21 42 28" src="https://user-images.githubusercontent.com/20021589/200708145-59ec0550-5cc1-4d88-b32c-c1ebf6228b84.png">
