### PR TITLE
Complete resource button when no auth

### DIFF
--- a/src/components/common/complete-toggle/CompleteToggle.js
+++ b/src/components/common/complete-toggle/CompleteToggle.js
@@ -1,8 +1,10 @@
 import { ToggleButton } from 'primereact/togglebutton';
 
-export const CompleteToggle = ({ completed, onChangeHandler }) => {
+export const CompleteToggle = ({ completed, onChangeHandler, disabled }) => {
+  const toggleDisabled = disabled ? 'p-disabled' : '';
   return (
     <ToggleButton
+      className={`CompleteResourceToggleButton ${toggleDisabled}`}
       onLabel="Completado"
       offLabel="No Completado"
       onIcon="pi pi-check"

--- a/src/components/resource-section/resource-complete-button/ResourceCompleteButton.js
+++ b/src/components/resource-section/resource-complete-button/ResourceCompleteButton.js
@@ -1,0 +1,31 @@
+import { CompleteToggle } from '@components/common/complete-toggle/CompleteToggle';
+import useCurrentUser from '@hooks/useCurrentUser';
+import useLoginDialog from '@hooks/useLoginDialog';
+import ResourceCompleteButtonAuth from './ResourceCompleteButtonAuth';
+
+const ResourceCompleteButton = ({ resourceId }) => {
+  const currentUser = useCurrentUser();
+  const loginDialog = useLoginDialog();
+
+  if (currentUser) {
+    return <ResourceCompleteButtonAuth resourceId={resourceId} />;
+  }
+
+  return (
+    <div
+      className="cardEvaluation"
+      onClick={() => {
+        loginDialog.setDisplayLoginDialog(true);
+      }}
+      onKeyPress={null}
+      role="button"
+      tabIndex="0"
+      data-pr-tooltip="Ingresa para poder completar un recurso"
+      data-pr-position="left"
+    >
+      <CompleteToggle disabled={true} />
+    </div>
+  );
+};
+
+export default ResourceCompleteButton;

--- a/src/components/resource-section/resource-complete-button/ResourceCompleteButtonAuth.js
+++ b/src/components/resource-section/resource-complete-button/ResourceCompleteButtonAuth.js
@@ -1,0 +1,39 @@
+import useGet from '@hooks/useGet';
+import { endpoints } from '@utils/endpoints';
+import { CompleteToggle } from '@components/common/complete-toggle/CompleteToggle';
+
+const ResourceCompleteButtonAuth = ({ resourceId }) => {
+  const {
+    data: isCompleted,
+    isLoading: isLoadingCompleted,
+    isError: isErrorCompleted,
+    mutate: updateCompleted,
+  } = useGet(endpoints('isResourceCompleted', resourceId));
+
+  if (isLoadingCompleted) return 'loading';
+  if (isErrorCompleted) return 'error';
+
+  const checkboxChangeHandler = (clicked) => {
+    const requestOptions = {
+      method: clicked.value ? 'POST' : 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+    };
+    fetch(endpoints('isResourceCompleted', resourceId), requestOptions).then(
+      (response) => {
+        if (response.ok) {
+          updateCompleted();
+        }
+      }
+    );
+  };
+
+  return (
+    <CompleteToggle
+      completed={isCompleted.completed}
+      onChangeHandler={checkboxChangeHandler}
+      disabled={false}
+    />
+  );
+};
+
+export default ResourceCompleteButtonAuth;

--- a/src/components/resource-section/resource-section/ResourceSection.js
+++ b/src/components/resource-section/resource-section/ResourceSection.js
@@ -30,45 +30,17 @@ const ResourceSection = ({
     mutate: updateEvaluations,
   } = useGet(endpoints('resourceEvaluations', resourceId));
 
-  const {
-    data: isCompleted,
-    isLoading: isLoadingCompleted,
-    isError: isErrorCompleted,
-    mutate: updateCompleted,
-  } = useGet(endpoints('isResourceCompleted', resourceId));
-
-  const checkboxChangeHandler = (clicked) => {
-    const requestOptions = {
-      method: clicked.value ? 'POST' : 'DELETE',
-      headers: { 'Content-Type': 'application/json' },
-    };
-    fetch(endpoints('isResourceCompleted', resourceId), requestOptions).then(
-      (response) => {
-        if (response.ok) {
-          updateCompleted();
-        }
-      }
-    );
-  };
-
-  if (
-    isLoadingResource ||
-    isLoadingAverage ||
-    isLoadingEvaluations ||
-    isLoadingCompleted
-  )
+  if (isLoadingResource || isLoadingAverage || isLoadingEvaluations)
     return <Skeleton shape="rectangle" width="100%" height="100%" />;
 
   if (isErrorResource) return <Error reset={updateResource} />;
   if (isErrorAverage) return <Error reset={updateAverage} />;
   if (isErrorEvaluations) return <Error reset={updateEvaluations} />;
-  if (isErrorCompleted) return <Error reset={updateCompleted} />;
 
   const resource = {
     name: resourceData.name,
     url: resourceData.url,
     average_evaluation: average_evaluation.average_evaluation,
-    completed: isCompleted.completed,
   };
 
   const updatesAddEvaluation = {
@@ -83,7 +55,6 @@ const ResourceSection = ({
       activeResource={resource}
       updatesAddEvaluation={updatesAddEvaluation}
       evaluations={evaluations}
-      checkboxChangeHandler={checkboxChangeHandler}
     />
   );
 };

--- a/src/components/resources-section/resource-sidebar/ResourceSidebar.js
+++ b/src/components/resources-section/resource-sidebar/ResourceSidebar.js
@@ -1,10 +1,10 @@
 import { Sidebar } from 'primereact/sidebar';
 import { Card } from 'primereact/card';
-import { CompleteToggle } from '@components/common/complete-toggle/CompleteToggle';
 import LinkButton from '@components/resource-section/link-button/LinkButton';
 import AddEvaluation from '@components/resource-section/add-evaluation/AddEvaluation';
 import Average from '@components/resources-section/average/Average';
 import EvaluationList from '@components/resource-section/evaluation-list/EvaluationList';
+import ResourceCompleteButton from '@components/resource-section/resource-complete-button/ResourceCompleteButton';
 
 const ResourceSidebar = ({
   onHideHandler,
@@ -12,7 +12,6 @@ const ResourceSidebar = ({
   updatesAddEvaluation,
   resourceId,
   evaluations,
-  checkboxChangeHandler,
 }) => {
   return (
     <Sidebar
@@ -23,9 +22,9 @@ const ResourceSidebar = ({
       dismissable={false}
       style={{ width: '25%' }}
     >
-      <CompleteToggle
+      <ResourceCompleteButton
         completed={activeResource.completed}
-        onChangeHandler={checkboxChangeHandler}
+        resourceId={resourceId}
       />
       <h1>{activeResource.name}</h1>
       <Card title="Evaluación promedio">


### PR DESCRIPTION
# Context
By now, when an unauthenticated user visit the sidebar of resources in the Lu page, an error is displayed on console log because `ResourceSection` is calling an endpoint that need authentication. 

With the introduced changes, the button in `ResourceCompleteButton` is disabled, so it doesn't trigger any action. Also, a tooltip is displayed when the mouse is passed over and a modal is displayed when clicked on the evaluation card.

# Before
![image](https://user-images.githubusercontent.com/17869861/200729510-13908e6d-35fc-46ee-b24f-5ffb9a666fc4.png)

# After
![image](https://user-images.githubusercontent.com/17869861/200729538-8b7a5ad1-4461-44d9-9eb2-2f962b82e7e7.png)

# QA
1. Log out
2. go to http://localhost:3001/learning-units/1
3. In any resource, click on the "Ver recurso" button.
4. In the sidebar, the button to mark the resource as completed should be disabled.
5.  Pass the mouse over the widgets, the message "Ingresa para poder completar un recurso" is displayed.
6. Click on the button, a modal inviting to sign in is displayed.