### PR TITLE
Fix: console error when creating a empty comment on a resource

### DIFF
--- a/src/components/resource-evaluation-comment/ResourceEvaluationComment.js
+++ b/src/components/resource-evaluation-comment/ResourceEvaluationComment.js
@@ -21,7 +21,7 @@ const ResourceEvaluationComment = ({ evaluation }) => {
           {evaluation.user_name + ' escribió el ' + evaluation.created_at}
         </h5>
         <InputTextarea
-          value={evaluation.comment}
+          value={evaluation.comment || ''}
           disabled={true}
           rows={4}
           cols={20}


### PR DESCRIPTION
When giving a evaluation to a resource with an empty comment, the console gives an error related to using a null value for a text.  In this PR we modified the ResourceEvaluationComment component to check if the comment is a null value.

## Before
![Screen Shot 2022-11-09 at 10 29 00](https://user-images.githubusercontent.com/20021589/200843869-d1a34f3d-806d-4110-a012-2eee8d8dcb7a.png)


## After
![Screen Shot 2022-11-09 at 10 28 22](https://user-images.githubusercontent.com/20021589/200843767-2bd3e550-208d-4492-a020-b58c47fc831d.png)
