### PR TITLE
fix(resource-list): align multi-line text to the center

### DIFF
--- a/src/components/cycle-section/learning-units-section/learning-unit-list-item/LearningUnitListItem.module.scss
+++ b/src/components/cycle-section/learning-units-section/learning-unit-list-item/LearningUnitListItem.module.scss
@@ -1,6 +1,7 @@
 .cardFull {
   width: 50%;
   transition: all 0.3s ease-in-out;
+
   &:hover {
     transform: scale(1.05);
     background-color: #f5f5f5;
@@ -30,16 +31,20 @@
   font-weight: 700;
   text-transform: uppercase;
   color: black;
+  text-align: center;
+
   span {
     font-size: 0.6rem;
     letter-spacing: 0.5rem;
     margin-bottom: 0.4rem;
     font-style: italic;
   }
+
   a {
     text-decoration: none;
     color: black;
     transition: all 0.3s ease-in-out;
+
     &:hover {
       color: rgb(49, 1, 121);
     }
@@ -53,6 +58,7 @@
     box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.7);
     transition: all 0.3s ease-in-out;
     box-shadow: inset 0 0 12px 4px rgba(255, 255, 255, 0.8);
+
     &:hover {
       border-radius: 50% 10%;
       cursor: pointer;


### PR DESCRIPTION
Before
<img width="1489" alt="Screen Shot 2022-11-09 at 11 35 32" src="https://user-images.githubusercontent.com/70340509/200858960-16d2185a-1cdd-421d-be98-9d25c5c75ab5.png">
After
<img width="1450" alt="Screen Shot 2022-11-09 at 11 35 18" src="https://user-images.githubusercontent.com/70340509/200858973-2a941d30-420f-4e7b-9d6b-ac8b76b19415.png">
