### PR TITLE
fix(resource-name): remove link to a page that didnt exist

### DIFF
--- a/src/components/resources-section/resources-list-item/ResourcesListItem.js
+++ b/src/components/resources-section/resources-list-item/ResourcesListItem.js
@@ -1,7 +1,6 @@
 import { Button } from 'primereact/button';
 import Average from '../average/Average';
 import styles from './ResourcesListItem.module.scss';
-import Link from 'next/link';
 import Image from 'next/image';
 import profilePic from '@utils/images/resource.jpg';
 import ResourceLabels from '../resource-labels/ResourceLabels';
@@ -20,9 +19,7 @@ const ResourcesListItem = ({ resource, resourceViewButtonHandler }) => {
             alt={resource.name}
           />
           <div>
-            <div className={styles.resourceName}>
-              <Link href={`/resources/${resource.id}`}>{resource.name}</Link>
-            </div>
+            <div className={styles.resourceName}>{resource.name}</div>
             <ResourceLabels resourceLabels={resource.resource_labels} />
             <div className={styles.resourceValidation}>
               <Average

--- a/src/components/resources-section/resources-list-item/ResourcesListItem.module.scss
+++ b/src/components/resources-section/resources-list-item/ResourcesListItem.module.scss
@@ -36,6 +36,7 @@
   font-weight: 700;
   text-align: center;
   padding: 0.5rem 0 0;
+  text-transform: uppercase;
 
   a {
     color: #2a2a33;


### PR DESCRIPTION
The resource name in the scroller in learning unit's page had a link to the resource page ('/resources/{resource_id}'), which doesn't exist.
