### PR TITLE
Change number of LU per page

### DIFF
--- a/src/components/cycle-section/learning-units-section/learning-units-list/LearningUnitsList.js
+++ b/src/components/cycle-section/learning-units-section/learning-units-list/LearningUnitsList.js
@@ -31,7 +31,7 @@ const LearningUnitsList = ({ learningUnits, mutate }) => {
         layout="list"
         itemTemplate={renderListItem}
         paginator
-        rows={10}
+        rows={8}
       />
     </div>
   );

--- a/src/components/cycle-section/learning-units-section/learning-units-list/LearningUnitsList.js
+++ b/src/components/cycle-section/learning-units-section/learning-units-list/LearningUnitsList.js
@@ -31,7 +31,7 @@ const LearningUnitsList = ({ learningUnits, mutate }) => {
         layout="list"
         itemTemplate={renderListItem}
         paginator
-        rows={9}
+        rows={10}
       />
     </div>
   );


### PR DESCRIPTION
By now, in the cycle page there are displayed 9 LU cards per page, but this unintuitive, as one space is left empty. This PR change that number to 8, so there are no empty spaces in the page.

# before
![image](https://user-images.githubusercontent.com/17869861/200908120-b9c14463-b528-4a41-8987-706659ac5fdd.png)

# After

![image](https://user-images.githubusercontent.com/17869861/200907855-470676f4-2dab-4745-bac2-32e4a8a10f15.png)

